### PR TITLE
Style adopt/pagination

### DIFF
--- a/client/src/components/Adopt/Adopt.js
+++ b/client/src/components/Adopt/Adopt.js
@@ -50,7 +50,7 @@ export default function Adopt(){
                 <Filters/>
             </div>
             <div className={style.cardContainer}>
-                <Paginate/>
+                
                 {renderPerPage ?
                     renderPerPage.map(pet => (
                         <Card 
@@ -63,6 +63,8 @@ export default function Adopt(){
                     :
                     <Loading/>
                 }
+                
+                <Paginate/>
             </div>
         </>
     )

--- a/client/src/components/Adopt/Adopt.module.css
+++ b/client/src/components/Adopt/Adopt.module.css
@@ -260,11 +260,29 @@
 ul{
     list-style: none;
     display: flex;
-    gap:30px;
+    justify-content: center;
+    align-items: center;
+    gap:10px;
     cursor: pointer;
+    text-align: center;
+}
+ul li{
+    color: white;
+    padding: 10px;
+    padding: 5px 11px 5px 11px;
+    border-radius: 100%;
+    /* height: 30px; */
+    border: 1.4px solid rgb(99, 59, 218);
+    transition: 1s;
 }
 .pages:hover{
-    color: red;
+    background-color: rgb(99, 59, 218);
+}
+.arrow{
+    /* background-color: red; */
+    border: none;
+    font-size: 30px;
+    color: rgb(99, 59, 218);
 }
 
 

--- a/client/src/components/Adopt/Filters/Paginate.js
+++ b/client/src/components/Adopt/Filters/Paginate.js
@@ -7,7 +7,6 @@ import style from '../Adopt.module.css'
 
 export default function Paginate(){
     
-    
     const dispatch = useDispatch()
     
     const {filtered} = useSelector(state => state.petsFiltered)
@@ -31,14 +30,21 @@ export default function Paginate(){
 
     return(
         <>
+            {pagesUI.length > 1 && 
             <ul>
-                {pagesUI.length &&
+                <li className={style.arrow}>
+                    <i className="fa-solid fa-circle-left" ></i>
+                </li>
+                {
                     pagesUI.map(n=>(
-                        //Revisar si esta bien usar LI
                         <li key={n} className={style.pages} onClick={e => handleSelect(e)} value={n} >{n}</li>
                     ))
                 }
+                <li className={style.arrow}>
+                    <i className="fa-solid fa-circle-right"></i>
+                </li>
             </ul>
+            }
         </>
     )
 }


### PR DESCRIPTION
Una PR cortita pero para no mezclarlo con otros temas, agrego un poco de estilo al paginado de adopt.
Quedaria pendiente darle funcionalidad a los botones de pagina siguiente y anterior.

![image](https://user-images.githubusercontent.com/85043233/181596975-29878d18-5ab7-41be-89d9-cee82d727aae.png)

Despues fijense si se les rompe o anda bien. 
Agrego a trello la tarea de darle funcionalidad a los botones <- y -> por si alguno se libera, sino yo el finde lo hago .